### PR TITLE
Sorts the categories when appending them to the annotation

### DIFF
--- a/voc2coco.py
+++ b/voc2coco.py
@@ -94,7 +94,7 @@ def convert(xml_list, xml_dir, json_file):
             json_dict['annotations'].append(ann)
             bnd_id = bnd_id + 1
 
-    for cate, cid in categories.items():
+    for cate, cid in sorted(categories.items(), key=lambda item: item[1]):
         cat = {'supercategory': 'none', 'id': cid, 'name': cate}
         json_dict['categories'].append(cat)
     json_fp = open(json_file, 'w')


### PR DESCRIPTION
Got into some trouble using this code for converting annotations. Since regular python dicts are not sorted, and this code basically scrambles the "categories" list in the annotation, any annotation parser which attempt to access the categories by index instead of comparing the "id" value will map incorrectly.